### PR TITLE
Add booking suite scaffold

### DIFF
--- a/booking-suite/.env.example
+++ b/booking-suite/.env.example
@@ -1,0 +1,19 @@
+# Database
+DATABASE_URL=postgresql://user:pass@localhost:5432/bookings
+SUPABASE_URL=https://xyzcompany.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+
+# Square
+SQUARE_ACCESS_TOKEN=your-square-token
+SQUARE_LOCATION_ID=your-location-id
+
+# Twilio
+TWILIO_ACCOUNT_SID=your-sid
+TWILIO_AUTH_TOKEN=your-token
+TWILIO_FROM_NUMBER=+15551234567
+
+# Resend
+RESEND_API_KEY=your-resend-key
+
+NEXT_PUBLIC_SUPABASE_URL=$SUPABASE_URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY

--- a/booking-suite/README.md
+++ b/booking-suite/README.md
@@ -1,0 +1,12 @@
+# Booking Suite
+
+Minimal white-label booking platform scaffold.
+
+## Getting Started
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Create a `.env` file based on `.env.example` with your database and API keys.

--- a/booking-suite/next-env.d.ts
+++ b/booking-suite/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat" />
+
+declare module 'react-big-calendar';

--- a/booking-suite/next.config.js
+++ b/booking-suite/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/booking-suite/package.json
+++ b/booking-suite/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "booking-suite",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@prisma/client": "latest",
+    "@supabase/supabase-js": "latest",
+    "@tanstack/react-query": "latest",
+    "@trpc/server": "latest",
+    "@trpc/react-query": "latest",
+    "@square/square": "latest",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "next": "14.0.0",
+    "react-big-calendar": "latest",
+    "shadcn-ui": "latest",
+    "twilio": "latest",
+    "resend": "latest"
+  },
+  "devDependencies": {
+    "prisma": "latest",
+    "tailwindcss": "latest",
+    "postcss": "latest",
+    "autoprefixer": "latest",
+    "typescript": "^5.0.0"
+  }
+}

--- a/booking-suite/postcss.config.js
+++ b/booking-suite/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/booking-suite/prisma/migrations/20230609000000_init/migration.sql
+++ b/booking-suite/prisma/migrations/20230609000000_init/migration.sql
@@ -1,0 +1,29 @@
+-- Initial migration
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE "User" (
+  "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "email" TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE "Service" (
+  "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "name" TEXT NOT NULL,
+  "duration" INTEGER NOT NULL,
+  "price" INTEGER NOT NULL
+);
+
+CREATE TABLE "Booking" (
+  "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "userId" UUID REFERENCES "User"("id"),
+  "serviceId" UUID NOT NULL REFERENCES "Service"("id"),
+  "start" TIMESTAMP NOT NULL,
+  "end" TIMESTAMP NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'PENDING'
+);
+
+CREATE TABLE "Payment" (
+  "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "bookingId" UUID NOT NULL REFERENCES "Booking"("id"),
+  "status" TEXT NOT NULL
+);

--- a/booking-suite/prisma/schema.prisma
+++ b/booking-suite/prisma/schema.prisma
@@ -1,0 +1,41 @@
+ datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+ }
+
+ generator client {
+  provider = "prisma-client-js"
+ }
+
+ model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  bookings  Booking[]
+ }
+
+ model Service {
+  id       String   @id @default(uuid())
+  name     String
+  duration Int
+  price    Int
+  bookings Booking[]
+ }
+
+ model Booking {
+  id        String   @id @default(uuid())
+  user      User?    @relation(fields: [userId], references: [id])
+  userId    String?
+  service   Service  @relation(fields: [serviceId], references: [id])
+  serviceId String
+  start     DateTime
+  end       DateTime
+  status    String   @default("PENDING")
+  Payment   Payment?
+ }
+
+ model Payment {
+  id        String   @id @default(uuid())
+  booking   Booking  @relation(fields: [bookingId], references: [id])
+  bookingId String
+  status    String
+ }

--- a/booking-suite/src/app/api/cron/digest/route.ts
+++ b/booking-suite/src/app/api/cron/digest/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/server/db';
+
+export async function GET() {
+  // send digest email / SMS
+  const upcoming = await prisma.booking.findMany({
+    where: { status: 'PENDING' },
+  });
+  console.log('Digest', upcoming.length);
+  return NextResponse.json({ ok: true });
+}

--- a/booking-suite/src/app/api/trpc/[trpc]/route.ts
+++ b/booking-suite/src/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,13 @@
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { router } from '@/server/routers/_app';
+import { NextRequest } from 'next/server';
+
+const handler = (req: NextRequest) =>
+  fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router,
+    createContext: () => ({}),
+  });
+
+export { handler as GET, handler as POST };

--- a/booking-suite/src/app/api/webhooks/square/route.ts
+++ b/booking-suite/src/app/api/webhooks/square/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/server/db';
+
+export async function POST(req: NextRequest) {
+  const event = await req.json();
+  if (event.type === 'payment.updated') {
+    const { bookingId } = event.data.object.metadata;
+    await prisma.booking.update({
+      where: { id: bookingId },
+      data: { status: 'CONFIRMED' },
+    });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/booking-suite/src/app/booking/page.tsx
+++ b/booking-suite/src/app/booking/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+import Calendar from '@/components/Calendar';
+
+export default function BookingPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-semibold mb-4">Book an Appointment</h1>
+      <Calendar />
+    </main>
+  );
+}

--- a/booking-suite/src/app/dashboard/page.tsx
+++ b/booking-suite/src/app/dashboard/page.tsx
@@ -1,0 +1,8 @@
+export default function Dashboard() {
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-semibold">Dashboard</h1>
+      <p>Protected admin area.</p>
+    </main>
+  );
+}

--- a/booking-suite/src/app/globals.css
+++ b/booking-suite/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/booking-suite/src/app/layout.tsx
+++ b/booking-suite/src/app/layout.tsx
@@ -1,0 +1,13 @@
+import './globals.css';
+import Providers from '@/components/Providers';
+import { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50">
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/booking-suite/src/app/page.tsx
+++ b/booking-suite/src/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">Welcome to Booking Suite</h1>
+    </main>
+  );
+}

--- a/booking-suite/src/components/Calendar.tsx
+++ b/booking-suite/src/components/Calendar.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { useState } from 'react';
+import { Calendar as BigCalendar, momentLocalizer, SlotInfo } from 'react-big-calendar';
+import moment from 'moment';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+
+const localizer = momentLocalizer(moment);
+
+export default function Calendar() {
+  const [events, setEvents] = useState([]);
+
+  const handleSelectSlot = (slot: SlotInfo) => {
+    // TODO integrate booking.create
+    alert(`Selected ${slot.start.toString()}`);
+  };
+
+  return (
+    <BigCalendar
+      selectable
+      localizer={localizer}
+      events={events}
+      startAccessor="start"
+      endAccessor="end"
+      style={{ height: 500 }}
+      onSelectSlot={handleSelectSlot}
+    />
+  );
+}

--- a/booking-suite/src/components/Providers.tsx
+++ b/booking-suite/src/components/Providers.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { trpc } from '@/lib/trpc';
+import { ReactNode } from 'react';
+
+const queryClient = new QueryClient();
+const trpcClient = trpc.createClient({ url: '/api/trpc' });
+
+export default function Providers({ children }: { children: ReactNode }) {
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </trpc.Provider>
+  );
+}

--- a/booking-suite/src/lib/trpc.ts
+++ b/booking-suite/src/lib/trpc.ts
@@ -1,0 +1,4 @@
+import { createTRPCReact } from '@trpc/react-query';
+import type { AppRouter } from '@/server/routers/_app';
+
+export const trpc = createTRPCReact<AppRouter>();

--- a/booking-suite/src/server/db.ts
+++ b/booking-suite/src/server/db.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+import { createClient } from '@supabase/supabase-js';
+
+export const prisma = new PrismaClient();
+
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);

--- a/booking-suite/src/server/routers/_app.ts
+++ b/booking-suite/src/server/routers/_app.ts
@@ -1,0 +1,15 @@
+import { initTRPC } from '@trpc/server';
+import superjson from 'superjson';
+import { bookingRouter } from './booking';
+import { serviceRouter } from './service';
+import { dashboardRouter } from './dashboard';
+
+const t = initTRPC.create({ transformer: superjson });
+
+export const router = t.router({
+  booking: bookingRouter,
+  service: serviceRouter,
+  dashboard: dashboardRouter,
+});
+
+export type AppRouter = typeof router;

--- a/booking-suite/src/server/routers/booking.ts
+++ b/booking-suite/src/server/routers/booking.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { prisma } from '../db';
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+
+export const bookingRouter = t.router({
+  create: t.procedure
+    .input(z.object({ serviceId: z.string(), start: z.date(), end: z.date() }))
+    .mutation(async ({ input }) => {
+      // simplified create booking
+      const booking = await prisma.booking.create({ data: input });
+      return booking;
+    }),
+});

--- a/booking-suite/src/server/routers/dashboard.ts
+++ b/booking-suite/src/server/routers/dashboard.ts
@@ -1,0 +1,11 @@
+import { prisma } from '../db';
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+
+export const dashboardRouter = t.router({
+  stats: t.procedure.query(async () => {
+    const count = await prisma.booking.count();
+    return { count };
+  }),
+});

--- a/booking-suite/src/server/routers/service.ts
+++ b/booking-suite/src/server/routers/service.ts
@@ -1,0 +1,8 @@
+import { prisma } from '../db';
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+
+export const serviceRouter = t.router({
+  list: t.procedure.query(() => prisma.service.findMany()),
+});

--- a/booking-suite/tailwind.config.ts
+++ b/booking-suite/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+export default config;

--- a/booking-suite/tsconfig.json
+++ b/booking-suite/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/booking-suite/vercel.json
+++ b/booking-suite/vercel.json
@@ -1,0 +1,6 @@
+{
+  "crons": [{
+    "path": "/api/cron/digest",
+    "schedule": "0 7 * * *"
+  }]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 `booking-suite` app
- add Prisma schema and initial migration
- wire up tRPC routers and endpoints
- stub calendar component and booking/dashboard pages
- add API routes for Square webhook and daily digest cron

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d4ae94b48326ad78e73b9815efe4